### PR TITLE
Internal Update for New Athena Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,31 @@
 
 [![Hippocratic License HL3-CORE](https://img.shields.io/static/v1?label=Hippocratic%20License&message=HL3-CORE&labelColor=5e2751&color=bc8c3d)](https://firstdonoharm.dev/version/3/0/core.html)
 
-## Purpose
+Sublime provides a rule-based system for reliably inferring the details of an HTTP request or response based on the available context. It handles URL construction, header management, content-type inference, and serialization.
 
-Sublime provides a rule-based system for reliably inferring the details of an HTTP request or response based on the available context. It handles URL construction, header management, content-type inference, and serialization/deserialization.
+## Features
 
-The rulebase is modular, allowing rule "modules" to be added to improve Sublime's ability to enrich requests and responses.
+- Constructs URLs robustly from partial inputs.
+- Manages HTTP headers, including lists and single-valued variations.
+- Infers content types based on data structures.
+- Provides automatic serialization and deserialization of payloads.
+- Converts structures between canonical representations and standard Web Fetch structures.
 
 ## Installation
 
-Use your favorite package manager to install `@dashkite/sublime`.
+```bash
+pnpm install @dashkite/sublime
+```
 
 ## Usage
 
-```coffee
+Sublime works by creating a unified interface for composing HTTP requests and responses.
+
+```coffeescript
 import Sublime from "@dashkite/sublime"
 
-# Create a Sublime instance with default rules
 { Request, Response } = Sublime.make()
 
-# Build a request
 request = await Request.Builder
   .make
     url: "https://example.com/api"
@@ -30,16 +36,12 @@ request = await Request.Builder
     content: { hello: "world" }
   .get()
 
-console.log request.url.toString() # https://example.com/api
-console.log request.method # post (normalized)
-console.log request.headers.get "content-type" # application/json (inferred)
-console.log request.content # { hello: "world" } (deserialized from JSON string in output)
+console.log request.url.toString()
 ```
 
 ## Other Resources
 
 - [Reference](docs/reference.md)
-
-## Status
-
-Not suitable for production use. Please report bugs and feature requests via the issue tracker.
+- [Recipes](docs/recipes.md)
+- [Technical Notes](docs/technical-notes.md)
+- [Testing](docs/testing.md)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,150 @@
+# Usage Guides
+
+## Composing a Basic Request
+
+This task demonstrates converting a colloquial description of an HTTP POST request into a canonical Sublime form. Sublime enables developers to specify high-level intent and handles the underlying inference and serialization automatically. This separation lets creators focus on business logic instead of HTTP intricacies.
+
+```coffeescript
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+
+request = await Request.Builder
+  .make
+    url: "https://example.com/api"
+    method: "POST"
+    content: { account: "alice" }
+  .get()
+
+# integration logic for handling finalized requests goes here
+console.log request.url.toString()
+console.log request.method
+```
+
+1. Initialize a `Sublime` instance to access the `Request` tools.
+2. Provide the `url`, `method`, and `content` payload to the `Request.Builder`.
+3. Call `get()` to resolve the builder's Athena rules and retrieve the finalized request structure.
+4. Access the normalized `url` and `method` properties from the generated `Request.Value`.
+
+## Interpreting Server Responses
+
+This task illustrates evaluating an HTTP response structure. Sublime enables developers to assess success states and decode response payloads without writing boilerplate validation logic.
+
+```coffeescript
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+
+# simulation of incoming data from a network transport layer
+response = await Response.Builder
+  .make
+    status: 404
+    content: { error: "Not Found" }
+  .get()
+
+if not response.ok
+  console.log response.description
+  console.log response.content.error
+```
+
+1. Initialize a `Sublime` instance to access the `Response` tools.
+2. Provide the `status` and raw `content` to the `Response.Builder`.
+3. Call `get()` to generate the finalized `Response.Value`.
+4. Evaluate the `ok` boolean flag to determine if the status falls within the successful `2xx` range.
+5. Access the human-readable `description` and the deserialized `content` for error handling.
+
+## Managing Header Cardinality
+
+This task demonstrates managing complex HTTP headers across both requests and responses. Sublime enables developers to extract specific values from multi-valued headers without writing custom string-parsing routines.
+
+```coffeescript
+import Sublime from "@dashkite/sublime"
+
+{ Request, Response } = Sublime.make()
+
+request = await Request.Builder
+  .make
+    url: "https://example.com/api"
+    headers:
+      "Accept": "text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8"
+  .get()
+
+response = await Response.Builder
+  .make
+    status: 200
+    headers:
+      "Content-Type": "application/json; charset=utf-8"
+  .get()
+
+acceptHeader = request.headers.get "Accept"
+contentType = response.headers.get "Content-Type"
+```
+
+1. Instantiate both a `Request.Builder` and a `Response.Builder` containing complex headers.
+2. Resolve the builders to obtain the finalized `Value` objects.
+3. Call the `get` method on the `headers` field collections for both the request and the response.
+4. Retrieve the accurately parsed header strings, completely abstracted away from any internal array or concatenation structures.
+
+## Bridging to Native Web Transports
+
+This task outlines managing a full network lifecycle by translating finalized, canonical Sublime objects to and from target native Web structures. The `convert` capability handles bidirectional translation, converting a canonical Sublime `Request` out to a target `fetch` format, and converting a target native `Response` back into the canonical Sublime ecosystem.
+
+```coffeescript
+import Sublime from "@dashkite/sublime"
+import convert from "@dashkite/sublime/src/convert"
+
+{ Request, Response } = Sublime.make()
+
+request = await Request.Builder
+  .make
+    url: "https://example.com/api"
+    method: "GET"
+  .get()
+
+# delegation to an external networking library
+fetchRequest = await convert "fetch", request
+fetchResponse = await fetch fetchRequest
+
+# processing the native response back into a Sublime representation
+response = await convert "sublime", fetchResponse
+
+if response.ok
+  console.log response.content
+```
+
+1. Construct a `Request.Value` using the standard builder pattern.
+2. Use the `convert` function with the `"fetch"` target, passing the finalized `request`.
+3. Utilize the returned `fetchRequest` with native networking utilities.
+4. Pass the resulting native `fetchResponse` back through the `convert` function with the `"sublime"` target.
+5. Utilize the fully deserialized Sublime `Response.Value` within the application logic.
+
+## Accessing the Inference Iterator
+
+This task demonstrates tapping directly into the underlying Athena rules engine to observe processing. Both the `Request` and `Response` builders expose an iterator, allowing developers to monitor state mutations dynamically, emit custom metrics, or inject delegator routines into the resolution lifecycle.
+
+```coffeescript
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+builder = Request.Builder.make url: "https://example.com/api"
+
+# setup initial abstract state payload for the engine
+state = { input: builder.input, output: {}, errors: [], working: {} }
+
+# obtain the async iterator from the underlying Athena rulebase
+reactor = builder.rules.start state
+
+# consume processing events as they occur
+for await event from reactor
+  # custom logging or reactive logic goes here
+  console.log event.name
+
+# once the iterator completes, the output object represents the finalized request
+console.log state.output.url.toString()
+```
+
+1. Instantiate a builder (such as `Request.Builder`) with initial parameters.
+2. Construct a state object containing `input`, `output`, `errors`, and `working` registries.
+3. Call `start()` directly on the builder's `rules` property, passing the state to initialize the Athena engine iterator.
+4. Iterate asynchronously over the `reactor` to receive and process events.
+5. Read the finalized properties directly from the `state.output` object once the iterator completes.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,98 +1,290 @@
 # Reference
 
+## Concepts
+
+Sublime utilizes a rule-based inference engine to convert various colloquial forms of HTTP structures into a specific target form, by passing through a canonical Sublime form. Instead of manually specifying every header and parameter, creators provide a minimal, colloquial request or response that expresses their high-level intent. Sublime then infers the necessary details to construct a robust, canonical representation. 
+
+This process relies heavily on a builder pattern intertwined with the Athena rules engine. Builders collect initial colloquial inputs and evaluate them against registered rulebases. Once the engine reaches equilibrium, the builder emits a finalized `Value` object representing the fully resolved, canonical request or response. Finally, creators can transform these canonical `Value` objects into environment-specific target formats (such as the standard Web Fetch `Request` or `Response` objects) using the provided `convert` capability.
+
 ## Sublime
 
 ### make
 $make: rulebases \to sublime$
 
-Creates a Sublime instance with the given rulebases. Returns an object containing `Request` and `Response` constructors.
+Initializes a factory object containing `Request` and `Response` builders. By passing an array of rulebases, developers inject custom logic into the inference engine, allowing it to handle domain-specific content types, headers, or authorization schemes natively.
 
-```coffee
-{ Request, Response } = Sublime.make()
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+$ = Sublime.make []
+assert.ok $.Request.Builder
 ```
 
-## Request
+## Request.Builder
 
-### Request.Builder.make
+### make
 $make: input \to builder$
 
-Creates a new request builder with the given input.
+Instantiates a new request builder initialized with a colloquial `input` configuration. The builder acts as the entry point for the Athena rules engine, gathering this initial colloquial context before processing.
 
-### Request.Builder.get
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+builder = Request.Builder.make url: "https://example.com"
+
+assert.equal builder.input.url, "https://example.com"
+```
+
+### get
 $get: \dashrightarrow request$
 
-Asynchronously processes the input through the rulebases and returns a `Request.Value`.
+Processes the accumulated inputs asynchronously through the configured rulebases, generating the finalized `Request.Value`. During this phase, the internal engine infers missing headers, normalizes methods, and serializes payloads.
 
-### Request.Value.url
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com", method: "POST" ).get()
+
+assert.equal request.method, "POST"
+```
+
+## Request.Value
+
+### url
 $url \to xurl$
 
-The request URL.
+Returns the canonical URL representing the target endpoint of the request. The value is normalized to ensure structural consistency.
 
-### Request.Value.method
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com" ).get()
+
+assert.equal request.url.toString(), "https://example.com/"
+```
+
+### method
 $method \to string$
 
-The normalized request method.
+Returns the normalized HTTP method for the request. Sublime handles casing ensuring that methods conform to standard HTTP semantics.
 
-### Request.Value.headers
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com", method: "post" ).get()
+
+assert.equal request.method, "POST"
+```
+
+### headers
 $headers \to fields$
 
-The request headers.
+Returns a collection representing the HTTP headers attached to the request. This collection manages the complexities of header cardinality, such as merging list headers and enforcing single-valued constraints.
 
-### Request.Value.content
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com", headers: { "X-Test": "123" } ).get()
+
+assert.equal request.headers.get("X-Test"), "123"
+```
+
+### content
 $content \to any$
 
-The request content, automatically deserialized based on the `content-type` header.
+Returns the request body content. Sublime deserializes this content automatically based on the inferred or explicitly defined `content-type` header.
 
-## Response
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
 
-### Response.Builder.make
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com", content: { hello: "world" } ).get()
+
+assert.deepEqual request.content, { hello: "world" }
+```
+
+## Response.Builder
+
+### make
 $make: input \to builder$
 
-Creates a new response builder with the given input.
+Instantiates a new response builder initialized with a colloquial `input` configuration, establishing the baseline state for inference.
 
-### Response.Builder.get
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+builder = Response.Builder.make status: 200
+
+assert.equal builder.input.status, 200
+```
+
+### get
 $get: \dashrightarrow response$
 
-Asynchronously processes the input through the rulebases and returns a `Response.Value`.
+Processes the accumulated inputs asynchronously through the configured rulebases, returning the finalized `Response.Value`.
 
-### Response.Value.status
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+response = await Response.Builder.make( status: 404 ).get()
+
+assert.equal response.status, 404
+```
+
+## Response.Value
+
+### status
 $status \to number$
 
-The response status code.
+Returns the precise HTTP status code of the response.
 
-### Response.Value.ok
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+response = await Response.Builder.make( status: 201 ).get()
+
+assert.equal response.status, 201
+```
+
+### ok
 $ok \to boolean$
 
-True if the status code is in the 2xx range.
+Evaluates whether the response represents a successful operation. It returns `true` if the status code falls within the `2xx` range.
 
-### Response.Value.description
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+response = await Response.Builder.make( status: 204 ).get()
+
+assert.equal response.ok, true
+```
+
+### description
 $description \to string$
 
-The status description.
+Returns a human-readable phrase describing the status code, assisting in logging and debugging flows.
 
-### Response.Value.headers
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+response = await Response.Builder.make( status: 200 ).get()
+
+assert.equal response.description, "OK"
+```
+
+### headers
 $headers \to fields$
 
-The response headers.
+Returns a collection representing the HTTP headers attached to the response.
 
-### Response.Value.content
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+response = await Response.Builder.make( status: 200, headers: { "X-Response": "456" } ).get()
+
+assert.equal response.headers.get("X-Response"), "456"
+```
+
+### content
 $content \to any$
 
-The response content, automatically deserialized based on the `content-type` header.
+Returns the response body content, automatically deserialized according to the response's `content-type` header.
+
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Response } = Sublime.make()
+response = await Response.Builder.make( status: 200, content: { status: "success" } ).get()
+
+assert.deepEqual response.content, { status: "success" }
+```
 
 ## Fields
 
 ### get
 $get: name \to value$
 
-Retrieves the value of the named header, automatically parsed.
+Retrieves the value associated with the specified header field name, resolving any underlying structural nuances like comma-separated lists.
 
-## convert
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com", headers: { "Accept": "application/json" } ).get()
+
+assert.equal request.headers.get("Accept"), "application/json"
+```
+
+## Convert
+
+### convert
 $convert: target, value \dashrightarrow result$
 
-Converts a Sublime value to the target format.
+Translates a Sublime internal structure into a specialized format required by a `target` system. It currently translates directly to standard `fetch` structures, enabling seamless integration with native web APIs.
 
-```coffee
-# Convert a Sublime request to a Fetch request
+```coffeescript
+import assert from "node:assert"
+import Sublime from "@dashkite/sublime"
+import convert from "@dashkite/sublime/src/convert"
+
+{ Request } = Sublime.make()
+request = await Request.Builder.make( url: "https://example.com" ).get()
 fetchRequest = await convert "fetch", request
+
+assert.ok fetchRequest instanceof global.Request
 ```
+
+## Header Cardinality
+
+> [!WARNING]
+>
+> This document’s accuracy is suspect and should be cross-checked against [the specification](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1).
+
+List headers are multi-valued headers, which often allow for comma-separated values or headers that may appear more than once (which tacitly append new values).
+
+### Content Negotiation
+
+`Accept`, `Accept-Charset`, `Accept-Encoding`, `Accept-Language`, `Accept-Ranges`
+
+### Control
+
+`Allow`, `Cache-Control`, `Connection`, `Expect`, `Forwarded`, `Range`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`, `Vary`
+
+### Authentication And Metadata
+
+`WWW-Authenticate`, `Proxy-Authenticate`, `If-Match`, `If-None-Match`, `Accept-Patch`, `Accept-CH`, `IM`, `Preference-Applied`
+
+### Unary (Single-Valued) Headers
+
+`Authorization`, `Content-Length`, `Content-Type`, `Content-MD5`, `Date`, `ETag`, `Expires`, `Last-Modified`, `Location`, `Host`, `Origin`, `Referer`, `Retry-After`, `Server`, `User-Agent`, `Warning`, `Pragma`
+
+### Cookies
+
+- `Cookie` uses semicolon-separated name-value pairs within a single header line and does **not** follow comma-list syntax.
+- `Set-Cookie` must be repeated as separate header fields—attempts to combine multiple `Set-Cookie` values into one comma-separated line are deprecated and widely unsupported.

--- a/docs/technical-notes.md
+++ b/docs/technical-notes.md
@@ -1,0 +1,31 @@
+# Technical Notes
+
+### Conceptual Architecture
+
+HTTP request and response structures are fundamental building blocks of network communication, often characterized in computer science as the implementation of Representational State Transfer (REST) [Fielding, 2000]. However, many of their constituent forms contain domain-specific formatting that is information-dense and tricky to manipulate programmatically.
+
+When working with these structures, creators often write imperative flows with extensive checks, conditional control flow, and extra validation steps. This obscures the high-level goal of state transfer across the network and imposes a burden on the narrative context of the local code.
+
+Sublime acts as an abstract, generalized model of an HTTP request and response. It serves as the central hub in a hub-and-spoke transformation model, eliminating point-to-point data conversions and creating narrative clarity in the resulting code. Creators can focus on simple, declarative business logic instead of translating between environment-specific formats.
+
+### Colloquial to Canonical Inference
+
+A defining capability of Sublime is its support for a "colloquial" description of network operations. Creators can specify a request or response minimally using shorthand—focusing only on the intent of the operation—rather than meticulously populating every required header, content type, and structural detail of a complete HTTP message.
+
+Sublime leverages its underlying rule engine to perform the necessary inference on your behalf. It automatically expands the minimal colloquial representation into a robust, canonical version perfectly suited for standard network transfer. This abstraction creates narrative clarity in the code, ensuring that the primary goal of the state transfer is never obscured by the mechanics of the protocol.
+
+### The Athena Rule Engine
+
+Sublime addresses the complexity of managing HTTP structures by embedding the Athena rule engine. Athena evaluates rules until the state reaches a stable equilibrium (fixed-point iteration), eliminating the need for heavy inference mechanisms like the Rete algorithm.
+
+By relying on Athena, Sublime handles parsing, conditional checks, validation, confirmation, serialization, and schema assertions simultaneously. It interprets headers and media types according to strict HTTP standards. Because the architecture is built on Athena, developers can also access the internal event stream of the processing dynamically if desired. This establishes Sublime—alongside its companion library, Altair—as the recommended tool for handling high-level HTTP parsing concerns.
+
+### Authorization with Sierra
+
+Security and authentication logic often bloat HTTP request building. Sublime mitigates this by delegating to the DashKite Sierra library. Sierra utilizes polymorphic dispatch and a central registry to manage compound credentials securely (e.g., using JSON64 encoding and schemes like `credentials` or `rune`).
+
+By integrating seamlessly with Sierra, Sublime resolves authorization questions autonomously. It pulls the appropriate tokens and schemes without cluttering the HTTP assembly logic, allowing creators to keep their business logic focused on the primary state transfer goal rather than credential management.
+
+### HTTP Standards and Headers
+
+Sublime manages all HTTP constraints in strict adherence to industry standards established by the IETF and W3C. Specifically, it constructs and normalizes headers in compliance with RFC 9110 (HTTP Semantics) and manages media types seamlessly. By abstracting the intricacies of header cardinality and HTTP standards, Sublime ensures that network payloads are canonically correct by default.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,15 @@
+# Testing
+
+Sublime utilizes the `genie` task runner to orchestrate its testing pipeline. The testing approach verifies the behavior of request and response builders, content negotiation, serialization, and conversion to external formats.
+
+## Running Tests
+
+To run the full test suite, invoke the `genie` test task from the repository root:
+
+```bash
+npx genie test
+```
+
+## Testing Approach
+
+The tests employ a scenario-based model driven by `@dashkite/runner`, defining expected inputs and evaluating the resulting `Request` or `Response` structures. The suite thoroughly exercises edge cases around header cardinality and data conversion, including the translation of structures to and from Web Fetch representations. Mock authorizers and state delegates are utilized to test the integration points of the rule-based builder system.

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@dashkite/runner": "link:../runner"
   },
   "dependencies": {
-    "@dashkite/athena": "0.0.17",
+    "@dashkite/athena": "link:../athena",
     "@dashkite/generic": "0.9.32",
     "@dashkite/http-headers": "0.12.37",
     "@dashkite/joy": "link:../joy",

--- a/src/builder/index.coffee
+++ b/src/builder/index.coffee
@@ -1,15 +1,4 @@
-import * as Fn from "@dashkite/joy/function"
-import * as Time from "@dashkite/joy/time"
-import * as Obj from "@dashkite/joy/object"
 import { metaclass } from "@dashkite/joy/metaclass"
-import { Queue } from "@dashkite/joy/iterable"
-import Generic from "@dashkite/generic"
-
-start = ( reactor ) ->
-  done = false
-  while !done
-    { value, done } = await reactor.next()
-  value
 
 builder = ( T ) ->
 
@@ -32,7 +21,17 @@ builder = ( T ) ->
       self
 
     @getters
-      rules: -> Fn.pipe @constructor._rulebases
+      rules: ->
+        rulebases = @constructor._rulebases
+        start: ( state, options = {} ) ->
+          reactor = options.delegator
+          for rulebase in rulebases
+            reactor = rulebase.start state, { options..., delegator: reactor }
+          reactor
+        run: ( state, options = {} ) ->
+          for rulebase in rulebases
+            state = await rulebase.run state, options
+          state
 
     update: ( mutator ) ->
       @output = {}
@@ -46,7 +45,7 @@ builder = ( T ) ->
       mulligan = true
       loop
         state = { @input, @output, @errors, @working }
-        { @output, @errors, @working } = await start @rules.apply state
+        { @output, @errors, @working } = await @rules.run state
         if @errors.length == 0
           break
         else if mulligan

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -27,10 +27,8 @@ do ->
 
       $ = Sublime.make()
 
-      Runner
-
+      results = await Runner
         .make scenarios
-
         .apply
 
           "Request Builder": 
@@ -67,6 +65,24 @@ do ->
             "response":
               "*": ({ input: { body, options }}) ->
                 convert "sublime", new Response body, options
+
+      results.push await test "Iterator Delegation", ->
+        $ = Sublime.make()
+        builder = $.Request.Builder.make url: "http://example.com"
+        state = { input: builder.input, output: {}, errors: [], working: {} }
+        
+        events = []
+        mockDelegator = do ->
+          yield { name: "mock-event", state }
+          
+        reactor = builder.rules.start state, delegator: mockDelegator
+        for await event from reactor
+          events.push event
+        
+        assert.equal events[0].name, "mock-event"
+
+      results
+
 
 
   process.exit if success then 0 else 1


### PR DESCRIPTION
This is a companion pull request to this change in Athena: https://github.com/dashkite/athena/pull/6

This doesn't affect the public interface of Sublime. It's focused only on how Athena is used internally. It's so limited that sky-sublime was not affected at all.

Added more documentation, trying to nail the idea of colloquial to canonical representation mapping.